### PR TITLE
removed info about braava jet

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 pyirobot
 ========
 
-This ia a python module for controlling the iRobot Roomba 980 (and possibly Roomba 960 and Braava Jet, but those are untested)
+This is a python module for controlling the iRobot Roomba 980 (and possibly Roomba 960 and Braava (except Braava Jet), but those are untested)
 
 iRobot does not povide an official API for their robots; I reverse engineered this from the communication between my robot, the
 iRobot iOS app, and the Axeda IoT cloud service.  The names of methods and attributes are mapped as closely as possible to the


### PR DESCRIPTION
Braava Jet doesn't have WiFi, only Bluetooth, so I think it can't be accessed through this API library